### PR TITLE
release: v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - **(dispose_tracker)** dispose tracker as public global interactor - ([2e03b79](https://github.com/arxdeus/disposito/commit/2e03b79eaf447ea1efdd3b0ecdd1183d51e49806))
 - **(dispose_tracker)** purge on create/dispose each other holder - ([f38e5c9](https://github.com/arxdeus/disposito/commit/f38e5c91488b54db900df2fb767bdcb087ef1cbc))
--  [**BREAKING CHANGE**]disposito - ([ca1db16](https://github.com/arxdeus/disposito/commit/ca1db16623904e79f7ddd2351066d8fe29157857))
+-  [**BREAKING CHANGE**] disposito main logic - ([ca1db16](https://github.com/arxdeus/disposito/commit/ca1db16623904e79f7ddd2351066d8fe29157857))
 
 ### Miscellaneous Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+# Changelog
+
+## [0.1.0](https://github.com/arxdeus/disposito/compare/v0.0.0..0.1.0) - 2025-03-19
+
+### Bug Fixes
+
+- **(extensions)** change signatures to generics to allow subtypes - ([2e2759c](https://github.com/arxdeus/disposito/commit/2e2759cf47b4c7b7a9941a8f9329d3c477732541))
+
+### Features
+
+- **(dispose_tracker)** dispose tracker as public global interactor - ([2e03b79](https://github.com/arxdeus/disposito/commit/2e03b79eaf447ea1efdd3b0ecdd1183d51e49806))
+- **(dispose_tracker)** purge on create/dispose each other holder - ([f38e5c9](https://github.com/arxdeus/disposito/commit/f38e5c91488b54db900df2fb767bdcb087ef1cbc))
+-  [**BREAKING CHANGE**]disposito - ([ca1db16](https://github.com/arxdeus/disposito/commit/ca1db16623904e79f7ddd2351066d8fe29157857))
+
+### Miscellaneous Chores
+
+- **(disposable)** static method for tear-off - ([2ebea5b](https://github.com/arxdeus/disposito/commit/2ebea5bff8b6623c99616ff57091b13dce8c4247))
+- **(pubspec)** update description - ([a200d5e](https://github.com/arxdeus/disposito/commit/a200d5e0c20808282790365ec0d697194dc96e14))
+
+### Refactoring
+
+- code style + lint matching - ([bf533bb](https://github.com/arxdeus/disposito/commit/bf533bb064e6b6a549548a20cbdcf4dd3b7ac2cc))
+
+### Tests
+
+- update to new syntax - ([4a1cd5c](https://github.com/arxdeus/disposito/commit/4a1cd5cf4c80d7a9bb38f8901a2a68b0d3631335))
+- missing comma lint fix - ([412bd71](https://github.com/arxdeus/disposito/commit/412bd716443fe9e82a1d4dc6b524448a82cd1e5c))
+
+### Ci
+
+- wrong step variable name - ([d329299](https://github.com/arxdeus/disposito/commit/d329299bb9b524bcefaa3e2f9d752023a2a28776))
+- fix double slash on pr create - ([322b10f](https://github.com/arxdeus/disposito/commit/322b10f2589d5c23d1dbbc4ddd14d866641a24e5))
+
 ## 0.0.1
 
 - Initial version.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: disposito
 description: Semi-automatic dispose holder that allows centralised disposal of objects
-version: 0.0.1
+version: 0.1.0
 repository: https://github.com/arxdeus/disposito
 
 environment:


### PR DESCRIPTION
# Changelog

## [0.1.0](https://github.com/arxdeus/disposito/compare/v0.0.0..0.1.0) - 2025-03-19

### Bug Fixes

- **(extensions)** change signatures to generics to allow subtypes - ([2e2759c](https://github.com/arxdeus/disposito/commit/2e2759cf47b4c7b7a9941a8f9329d3c477732541))

### Features

- **(dispose_tracker)** dispose tracker as public global interactor - ([2e03b79](https://github.com/arxdeus/disposito/commit/2e03b79eaf447ea1efdd3b0ecdd1183d51e49806))
- **(dispose_tracker)** purge on create/dispose each other holder - ([f38e5c9](https://github.com/arxdeus/disposito/commit/f38e5c91488b54db900df2fb767bdcb087ef1cbc))
-  [**BREAKING CHANGE**] disposito main logic - ([ca1db16](https://github.com/arxdeus/disposito/commit/ca1db16623904e79f7ddd2351066d8fe29157857))

### Miscellaneous Chores

- **(disposable)** static method for tear-off - ([2ebea5b](https://github.com/arxdeus/disposito/commit/2ebea5bff8b6623c99616ff57091b13dce8c4247))
- **(pubspec)** update description - ([a200d5e](https://github.com/arxdeus/disposito/commit/a200d5e0c20808282790365ec0d697194dc96e14))

### Refactoring

- code style + lint matching - ([bf533bb](https://github.com/arxdeus/disposito/commit/bf533bb064e6b6a549548a20cbdcf4dd3b7ac2cc))

### Tests

- update to new syntax - ([4a1cd5c](https://github.com/arxdeus/disposito/commit/4a1cd5cf4c80d7a9bb38f8901a2a68b0d3631335))
- missing comma lint fix - ([412bd71](https://github.com/arxdeus/disposito/commit/412bd716443fe9e82a1d4dc6b524448a82cd1e5c))

### Ci

- wrong step variable name - ([d329299](https://github.com/arxdeus/disposito/commit/d329299bb9b524bcefaa3e2f9d752023a2a28776))
- fix double slash on pr create - ([322b10f](https://github.com/arxdeus/disposito/commit/322b10f2589d5c23d1dbbc4ddd14d866641a24e5))
