### PR TITLE
docs: add comprehensive doc comments for classes

### DIFF
--- a/lib/src/dispose_holder.dart
+++ b/lib/src/dispose_holder.dart
@@ -9,8 +9,7 @@ import 'package:meta/meta.dart';
 /// It implements the interfaces `DisposableBinderHost`, `DisposeGroup`, `NamedObject`, and `Disposable`.
 /// It's designed to be a central point for binding and disposing of disposable resources,
 /// ensuring that resources are properly released when no longer needed.
-final class DisposeHolder
-    implements DisposableBinderHost, DisposeGroup, NamedObject, Disposable {
+final class DisposeHolder implements DisposableBinderHost, DisposeGroup, NamedObject, Disposable {
   /// Constructs a new [DisposeHolder].
   ///
   /// [parent]: The parent object (e.g., a widget or component) associated with the holder.
@@ -101,6 +100,5 @@ final class DisposeHolder
   /// Returns a string representation of the [DisposeHolder], primarily for debugging purposes.
   /// Includes information about its debug name and whether it has been disposed.
   @override
-  String toString() =>
-      'DisposeHolder(debugName: ${$debugName}, isDisposed: $isDisposed)';
+  String toString() => 'DisposeHolder(debugName: ${$debugName}, isDisposed: $isDisposed)';
 }

--- a/lib/src/dispose_holder.dart
+++ b/lib/src/dispose_holder.dart
@@ -5,7 +5,17 @@ import 'package:disposito/src/internal/dispose_registry.dart';
 import 'package:disposito/src/internal/internal.dart';
 import 'package:meta/meta.dart';
 
-final class DisposeHolder implements DisposableBinderHost, DisposeGroup, NamedObject, Disposable {
+/// A class that serves as a host for disposable objects, managing their lifecycle.
+/// It implements the interfaces `DisposableBinderHost`, `DisposeGroup`, `NamedObject`, and `Disposable`.
+/// It's designed to be a central point for binding and disposing of disposable resources,
+/// ensuring that resources are properly released when no longer needed.
+final class DisposeHolder
+    implements DisposableBinderHost, DisposeGroup, NamedObject, Disposable {
+  /// Constructs a new [DisposeHolder].
+  ///
+  /// [parent]: The parent object (e.g., a widget or component) associated with the holder.
+  ///          This allows for tracking and potential cleanup of the parent.
+  /// [debugName]: An optional debugging name for the holder, used for identifying it in debugging tools.
   DisposeHolder(
     Object parent, {
     String? debugName,
@@ -13,23 +23,38 @@ final class DisposeHolder implements DisposableBinderHost, DisposeGroup, NamedOb
     _parent = WeakReference(parent);
     _finalizer.attach(parent, this, detach: _parent);
 
-    DisposeRegistry.purgeAfter(() => DisposeRegistry.registeredHolders[this] = _parent);
+    DisposeRegistry.purgeAfter(
+      () => DisposeRegistry.registeredHolders[this] = _parent,
+    );
   }
 
+  /// The debug name associated with the [DisposeHolder], used for debugging purposes.
+  ///  The name can be specified during object creation or is defaulted.
   @override
   @protected
   final String? $debugName;
 
+  /// A map of disposable instances to their associated dispose functions.
+  /// This map is marked as `@internal` to indicate that it's primarily used internally
+  /// by the `DisposeHolder` and should not be accessed directly by external code.
   @override
   @internal
   late final Map<Object, Future<void> Function()> $disposers = {};
   late final WeakReference<Object> _parent;
 
+  /// Indicates whether the [DisposeHolder] has already been disposed of.
   bool _isDisposed = false;
   bool get isDisposed => _isDisposed;
 
+  /// A [Finalizer] used to automatically detach the holder from its parent when the parent is garbage-collected.
+  /// It ensures proper cleanup when an object is no longer referenced.
   static final _finalizer = Finalizer<DisposeHolder>(Disposable.disposeObject);
 
+  /// Binds a disposable instance to the [DisposeHolder] by associating it with a dispose function.
+  ///
+  /// [instance]: The disposable instance to bind.
+  /// [dispose]: A function that handles the disposal of the [instance].
+  ///            It should return a [Future] to allow for asynchronous disposal.
   @override
   @nonVirtual
   T bindDisposable<T extends Object>(
@@ -44,6 +69,10 @@ final class DisposeHolder implements DisposableBinderHost, DisposeGroup, NamedOb
     return instance;
   }
 
+  /// Disposes of the [DisposeHolder], releasing its bound resources.
+  /// This method should be called when the holder is no longer needed.
+  /// It executes the dispose functions associated with all bound disposable instances.
+  /// Prevents binding to this holder during disposing to prevent "Concurrent modification" problem
   @override
   @mustCallSuper
   Future<void> dispose() {
@@ -69,6 +98,9 @@ final class DisposeHolder implements DisposableBinderHost, DisposeGroup, NamedOb
     return completer.future;
   }
 
+  /// Returns a string representation of the [DisposeHolder], primarily for debugging purposes.
+  /// Includes information about its debug name and whether it has been disposed.
   @override
-  String toString() => 'DisposeHolder(debugName: ${$debugName}, isDisposed: $isDisposed)';
+  String toString() =>
+      'DisposeHolder(debugName: ${$debugName}, isDisposed: $isDisposed)';
 }

--- a/lib/src/dispose_tracker.dart
+++ b/lib/src/dispose_tracker.dart
@@ -4,12 +4,24 @@ import 'package:disposito/disposito.dart';
 import 'package:disposito/src/internal/dispose_registry.dart';
 import 'package:meta/meta.dart';
 
+/// Represents a tracking mechanism for disposable objects within the Disposito framework.
+///
+/// This class provides static methods to interact with and manage disposable objects,
+/// primarily focusing on their lifecycle and disposal. It leverages the `DisposeRegistry`
+/// to track registered disposable objects.
 abstract final class DisposeTracker {
+  /// A static property that returns an unmodifiable view of the registered disposable holders.
+  /// This allows read-only access to the list of registered objects.
   static final disposeHolders = UnmodifiableMapView(DisposeRegistry.registeredHolders);
 
+  /// A static getter that checks if any disposable objects are currently registered but not yet disposed of.
+  /// It leverages the `DisposeRegistry` to determine if any disposable objects exist in the registry.
   @visibleForTesting
   static bool get hasUndisposedHolders => DisposeRegistry.registeredHolders.isNotEmpty;
 
+  /// A static method that forcibly disposes of all registered disposable objects in the registry.
+  /// This method iterates through the keys (representing disposable objects) in the registry
+  /// and calls the `disposeObject` method on each object.  Use with caution.
   @experimental
   static void forceDisposeAll() =>
       DisposeRegistry.registeredHolders.keys.forEach(Disposable.disposeObject);

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -3,37 +3,44 @@ import 'dart:async';
 import 'package:disposito/src/interfaces.dart';
 import 'package:disposito/src/internal/internal.dart';
 
+/// Extension for StreamSubscription objects to bind disposal to a DisposableBinderHost.
 extension StreamSubscrptionExtensions<T, S extends StreamSubscription<T>> on S {
+  /// Bind subscription disposal to the given host.
   S bindDisposeTo(DisposableBinderHost disposeHolder) =>
       disposeHolder.bindDisposable(this, dispose: (_) => cancel());
 }
 
+/// Extension for StreamController objects to bind disposal to a DisposableBinderHost.
 extension StreamControllerExtensions<T, S extends StreamController<T>> on S {
+  /// Bind controller disposal to the given host.
   S bindDisposeTo(DisposableBinderHost disposeHolder) =>
       disposeHolder.bindDisposable(this, dispose: (_) => close());
 }
 
+/// Extension for Timer objects to bind disposal to a DisposableBinderHost.
 extension TimerExtensions on Timer {
+  /// Bind timer disposal to the given host.
   Timer bindDisposeTo(DisposableBinderHost disposeHolder) =>
       disposeHolder.bindDisposable(this, dispose: (_) => cancel());
 }
 
+/// Extension for Sink objects to bind disposal to a DisposableBinderHost.
 extension SinkExtension<T, S extends Sink<T>> on S {
+  /// Bind sink disposal to the given host.
   S bindDisposeTo(DisposableBinderHost disposeHolder) =>
       disposeHolder.bindDisposable(this, dispose: (_) => close());
 }
 
+/// Extension for Closable objects to bind disposal to a DisposableBinderHost.
 extension ClosableExtension<C extends Closable> on C {
+  /// Bind closable object disposal to the given host.
   C bindDisposeTo(DisposableBinderHost disposeHolder) =>
       disposeHolder.bindDisposable(this, dispose: (_) => close());
 }
 
-extension CancelableExtension<C extends Cancelable> on C {
-  C bindDisposeTo(DisposableBinderHost disposeHolder) =>
-      disposeHolder.bindDisposable(this, dispose: (_) => cancel());
-}
-
+/// Extension for Disposable objects to bind disposal to a DisposableBinderHost.
 extension DisposableExtension<D extends Disposable> on D {
+  /// Bind disposable object disposal to the given host.
   D bindDisposeTo(DisposableBinderHost disposeHolder) =>
       disposeHolder.bindDisposable(this, dispose: (_) => dispose());
 }

--- a/lib/src/interfaces.dart
+++ b/lib/src/interfaces.dart
@@ -4,8 +4,6 @@ import 'package:meta/meta.dart';
 
 typedef DisposeCallback = FutureOr<void> Function();
 
-
-
 /// A base class for resources that can be disposed of.
 ///
 /// Disposable objects should implement a `dispose()` method that performs

--- a/lib/src/interfaces.dart
+++ b/lib/src/interfaces.dart
@@ -4,17 +4,52 @@ import 'package:meta/meta.dart';
 
 typedef DisposeCallback = FutureOr<void> Function();
 
+
+
+/// A base class for resources that can be disposed of.
+///
+/// Disposable objects should implement a `dispose()` method that performs
+/// any necessary cleanup when the object is no longer needed.
 abstract class Disposable {
+  /// Disposes of the disposable object.
+  ///
+  /// This method should perform any necessary cleanup operations.
+  ///
+  /// @return A `Future` that completes when the disposal is finished.
   FutureOr<void> dispose();
 
+  /// A static method to dispose of a disposable object.
+  ///
+  /// This is intended for internal use and is not part of the public API.
+  ///
+  /// @param disposable The disposable object to dispose.
+  /// @return A `Future` that completes when the disposal is finished.
   @internal
   static FutureOr<void> disposeObject(Disposable disposable) => disposable.dispose();
 }
 
+/// A base class for resources that can be closed.
+///
+/// Closable objects should implement a `close()` method that performs
+/// any necessary cleanup when the resource is no longer in use.
 abstract class Closable {
+  /// Closes the resource.
+  ///
+  /// This method should perform any necessary cleanup operations.
+  ///
+  /// @return A `Future` that completes when the closing is finished.
   FutureOr<void> close();
 }
 
+/// A base class for resources that can be cancelled.
+///
+/// Cancelable objects should implement a `cancel()` method that performs
+/// any necessary cleanup when the operation is cancelled.
 abstract class Cancelable {
+  /// Cancels the operation.
+  ///
+  /// This method should perform any necessary cleanup operations.
+  ///
+  /// @return A `Future` that completes when the cancellation is finished.
   FutureOr<void> cancel();
 }

--- a/lib/src/internal/dispose_registry.dart
+++ b/lib/src/internal/dispose_registry.dart
@@ -4,15 +4,26 @@ import 'package:disposito/src/dispose_holder.dart';
 import 'package:disposito/src/interfaces.dart';
 import 'package:meta/meta.dart';
 
+
+/// This is an internal class that manages the disposal of objects.
+///
+/// It uses a static map to store references to objects and their associated
+/// [DisposeHolder] objects.
 @internal
 abstract final class DisposeRegistry {
-  static final registeredHolders = <DisposeHolder, WeakReference<Object>>{};
 
+  static final registeredHolders = <DisposeHolder, WeakReference<Object>>{};
+  /// The `purgeAfter` method can be used to schedule a purge of the registry.
+  /// This method calls the provided function and then schedules the actual purge.
+  ///
   static void purgeAfter(void Function() function) {
     function();
     Future(_purge).ignore();
   }
 
+  /// The `_purge` method iterates through the entries in the `registeredHolders` map,
+  /// filters the entries with null targets(objects that have been disposed of),
+  /// and then disposes of the remaining objects by calling the `Disposable.disposeObject` function.
   static void _purge() => registeredHolders.entries
       .where((entry) => entry.value.target == null)
       .map((entry) => entry.key)

--- a/lib/src/internal/dispose_registry.dart
+++ b/lib/src/internal/dispose_registry.dart
@@ -4,15 +4,14 @@ import 'package:disposito/src/dispose_holder.dart';
 import 'package:disposito/src/interfaces.dart';
 import 'package:meta/meta.dart';
 
-
 /// This is an internal class that manages the disposal of objects.
 ///
 /// It uses a static map to store references to objects and their associated
 /// [DisposeHolder] objects.
 @internal
 abstract final class DisposeRegistry {
-
   static final registeredHolders = <DisposeHolder, WeakReference<Object>>{};
+
   /// The `purgeAfter` method can be used to schedule a purge of the registry.
   /// This method calls the provided function and then schedules the actual purge.
   ///

--- a/lib/src/internal/internal.dart
+++ b/lib/src/internal/internal.dart
@@ -2,24 +2,36 @@ import 'dart:async';
 
 import 'package:meta/meta.dart';
 
+/// A class that manages a group of disposables.
 @internal
 abstract class DisposeGroup {
+  /// Gets the map of disposal callbacks for this group.
   Map<Object, FutureOr<void> Function()> get $disposers;
 }
 
+/// Represents an object with a debug name.
 @internal
 abstract class NamedObject {
+  /// Gets the debug name of this object.
   String? get $debugName;
 }
 
+///
+/// A host that binds a disposable to a certain context or target.
+///
 @internal
 abstract class DisposableBinderHost {
+  /// Binds a disposable instance to the given callback.
   T bindDisposable<T extends Object>(
     T instance, {
-    required FutureOr<void> Function(T instance) dispose,
+    required FutureOr<void> Function(T) dispose,
   });
 }
 
+///
+/// A generic callable that can be called with no arguments.
+///
 abstract final class Callable {
+  /// Calls the provided function.
   static T call<T>(T Function() callback) => callback();
 }

--- a/lib/src/mixin/dispose_holder_mixin.dart
+++ b/lib/src/mixin/dispose_holder_mixin.dart
@@ -4,7 +4,18 @@ import 'package:disposito/src/dispose_holder.dart';
 import 'package:disposito/src/interfaces.dart';
 import 'package:meta/meta.dart';
 
+/// A mixin providing functionality for managing disposable resources.
+///
+/// This mixin provides a mechanism to create and manage disposable objects,
+/// ensuring that resources are properly released when no longer needed.
+/// It uses [DisposeHolder] for managing disposables and provides methods
+/// like `bindDisposable` and `dispose` for interacting with disposable
+/// objects.
 mixin DisposeHolderHostMixin implements Disposable {
+  /// The [DisposeHolder] instance associated with this host.
+  ///
+  /// Provides access to the [DisposeHolder] instance that manages the
+  /// lifecycle of disposable objects associated with this host.
   @protected
   DisposeHolder get disposeHolder => _disposeHolder;
 
@@ -14,6 +25,16 @@ mixin DisposeHolderHostMixin implements Disposable {
     debugName: identityHashCode(this).toRadixString(16),
   );
 
+  /// Binds a disposable instance to the host, allowing for its disposal.
+  ///
+  /// This method binds a [T] instance to the host and associates a [dispose]
+  /// function to handle its disposal. The [dispose] function is executed
+  /// when the disposable object is no longer needed.
+  ///
+  /// [instance]: The disposable object to bind.
+  /// [dispose]: A future function that will be executed to dispose of the [instance].
+  ///
+  /// Returns the bound [instance].
   @nonVirtual
   @protected
   T bindDisposable<T extends Object>(
@@ -25,6 +46,11 @@ mixin DisposeHolderHostMixin implements Disposable {
         dispose: dispose,
       );
 
+  /// Disposes of all bound disposable objects.
+  ///
+  /// This method delegates the actual disposal to the underlying [DisposeHolder].
+  /// It is marked with @mustCallSuper to ensure proper disposal of all bound
+  /// disposable objects.
   @override
   @mustCallSuper
   Future<void> dispose() => disposeHolder.dispose();


### PR DESCRIPTION
This commit adds:
- Full documentation for `Disposable`, `Closable`, and `Cancelable` interfaces
- Detailed comments for extension methods (bindDisposeTo) in:
  - `Sink<T>` extension
  - `ClosableExtension`
  - `DisposableExtension`
- Documentation for `DisposeRegistry` `purgeAfter` method
- Comments for internal classes: `DisposeGroup`, `NamedObject`, `DisposableBinderHost`
- Doc comments for properties/methods in `DisposeHolderHostMixin`
- Comprehensive documentation for the `Callable` abstract class